### PR TITLE
CI: build bats from C artifact

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,4 +1,3 @@
-# v3 — bats compiler bugs fixed on main
 name: check
 
 on:
@@ -23,22 +22,27 @@ jobs:
           mkdir -p bin
           cp src/CBOOT/patsopt bin/patsopt
 
-      - name: Cache bats toolchain
+      - name: Cache bats compiler
         id: cache-bats
         uses: actions/cache@v4
         with:
-          path: ~/bats-toolchain
-          key: bats-${{ runner.os }}-${{ hashFiles('.github/workflows/check.yml') }}
+          path: ~/bats-bin
+          key: bats-from-c-${{ runner.os }}-${{ hashFiles('.github/workflows/check.yml') }}
 
-      - name: Build bats
+      - name: Build bats from C
         if: steps.cache-bats.outputs.cache-hit != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          git clone https://github.com/bats-lang/bats.git ~/bats-toolchain
-          cd ~/bats-toolchain
-          cargo build --release
+          RUN_ID=$(gh run list --repo bats-lang/bats --branch main --status success --workflow check --limit 1 --json databaseId --jq '.[0].databaseId')
+          gh run download "$RUN_ID" --repo bats-lang/bats --name bats-c --dir ~/bats-c
+          cd ~/bats-c
+          make PATSHOME=$HOME/.ats2/ATS2-Postiats-int-0.4.2
+          mkdir -p ~/bats-bin
+          cp debug/bats ~/bats-bin/bats
 
       - name: bats check
         run: |
           git clone https://github.com/bats-lang/repository-prototype.git ~/repository
-          ~/bats-toolchain/target/release/bats lock --repository ~/repository
-          ~/bats-toolchain/target/release/bats check --repository ~/repository
+          ~/bats-bin/bats lock --repository ~/repository
+          ~/bats-bin/bats check --repository ~/repository


### PR DESCRIPTION
Switch CI to download the bats-c artifact and build with make instead of cargo.