### PR TITLE
Add missing dependencies to bats.toml

### DIFF
--- a/bats.toml
+++ b/bats.toml
@@ -2,3 +2,9 @@
 name = "toml"
 kind = "lib"
 unsafe = false
+
+[dependencies]
+"arith" = ""
+"array" = ""
+"result" = ""
+"str" = ""


### PR DESCRIPTION
Every #use now has a matching [dependencies] entry.